### PR TITLE
Replace httptest::with_mock_API -> with_mock_api, buildMockURL -> build_mock_url

### DIFF
--- a/tests/testthat/test.login.R
+++ b/tests/testthat/test.login.R
@@ -4,7 +4,7 @@ library(mockery)
 context("Login")
 
 test_that("Login procedure works", {
-  with_mock_API({
+  with_mock_api({
     expect_POST(sst <- superSecuredToken())
     expect_GET(sst <- temporaryToken("dummy"))
   })
@@ -14,8 +14,8 @@ test_that("Login procedure works", {
 test_that("Login unauthorized message is correct", {
   with_mock(
     status_code = mock(401L, cycle = T),
-    buildMockURL = mock("test.com/login-401.json", cycle = T),
-    with_mock_API({
+    build_mock_url = mock("test.com/login-401.json", cycle = T),
+    with_mock_api({
       expect_error(sst <- superSecuredToken(), regexp = "401")
     })
   )
@@ -26,7 +26,7 @@ Sys.setenv(GOODDATA_DOMAIN = "test.com")
 Sys.setenv(GOODDATA_PROJECT = "dummy")
 
 test_that("Correct auth code is captured from response header", {
-  with_mock_API({
+  with_mock_api({
     Sys.setenv(TZ='UTC')
     sst <- superSecuredToken()
     expect_match(sst, "^GDCAuthTT=")

--- a/tests/testthat/test.report.export.R
+++ b/tests/testthat/test.report.export.R
@@ -4,7 +4,7 @@ library(mockery)
 context("Report data")
 with_mock(
   authCookie = mock("", cycle = TRUE),
-  with_mock_API({
+  with_mock_api({
     test_that("Report definition is extracted correctly", {
 
       res <- getLastDefinition(810164L)
@@ -26,9 +26,9 @@ context("Error Codes")
 test_that("Error code is processed correctly",
   with_mock(
     status_code = mock(401L, cycle = T),
-    buildMockURL = mock("test.com/401.json", cycle = T),
+    build_mock_url = mock("test.com/401.json", cycle = T),
     authCookie = mock("", cycle = T),
-    with_mock_API({
+    with_mock_api({
       expect_error(res <- getLastDefinition(810164L), regex = "401")
       expect_error(res <- getReportRawUri(810164L), regex = "401")
       expect_error(res <- getReportData("test.com/dummy"), regex = "401")
@@ -39,13 +39,13 @@ test_that("Error code is processed correctly",
 test_that("Test that data is extracted correctly from large report",
   with_mock(
     status_code = mock(201L, 201L, 200L),
-    buildMockURL = mock("test.com/report-data-201.json",
+    build_mock_url = mock("test.com/report-data-201.json",
                         "test.com/report-data-201.json",
                         "test.com/report-data-200.csv"),
     http_type = mock("application/json", "application/json", "text/csv"),
     authCookie = mock("", cycle = T),
     {
-      with_mock_API({
+      with_mock_api({
         expect_output(res <- getReportData("test.com/dummy", 0.012), regexp = "0.012")
         expect_true(is.data.table(res))
         expect_identical(nrow(res), 2L)
@@ -57,11 +57,11 @@ test_that("Test that data is extracted correctly from large report",
 test_that("Test bad response with text message",
   with_mock(
     status_code = mock(503L, cycle = T),
-    buildMockURL = mock("test.com/503.txt", cycle = T),
+    build_mock_url = mock("test.com/503.txt", cycle = T),
     http_type = mock("text", cycle = T),
     authCookie = mock("", cycle = T),
     {
-      with_mock_API({
+      with_mock_api({
         expect_error(res <- getLastDefinition(5232L), regexp = "503")
       })
     }

--- a/tests/testthat/test.schedule.R
+++ b/tests/testthat/test.schedule.R
@@ -12,7 +12,7 @@ test_that("Schedule execution sends POST request" , {
 })
 
 with_mock(authCookie = mock("", cycle = F), {
-  with_mock_API({
+  with_mock_api({
     test_that("Schedule execution works" , {
       execution <- executeSchedule("abcd")
       expect_equal(execution, "test.com/gdc/projects/dummy/schedules/abcd/executions/1234")


### PR DESCRIPTION
Three years ago, [several functions were renamed](https://enpiar.com/r/httptest/news/#other-big-changes-and-enhancements) in the `httptest` 3.0.0 release for consistency with `httr` and `testthat`. Function aliases with the old naming were kept to avoid breaking packages, but in the [upcoming `httptest` 4.0.0 release](https://github.com/nealrichardson/httptest/issues/53), these deprecated functions are being removed. This PR updates your package to use the functions that will remain in the 4.0.0 release.

We plan to submit the `httptest` update to CRAN at the end of January. To avoid any potential nastygrams from CRAN, it would be ideal if you can update your package on CRAN with this change before then. Thanks!